### PR TITLE
Normalize UID casing in testPAndC PICC comparison

### DIFF
--- a/app/class/NTag424.tsx
+++ b/app/class/NTag424.tsx
@@ -794,7 +794,7 @@ Ntag424.testPAndC = async (pVal: any, cVal: any, uid: any, piccKey: any, macKey:
         keySize: 128 / 8,
     });
     const decryptedPiccData = CryptoJS.enc.Hex.stringify(decPiccData);
-    if (decryptedPiccData.startsWith("c7" + uid)) result.pTest = true;
+    if (decryptedPiccData.startsWith("c7" + uid.toLowerCase())) result.pTest = true;
 
     const sdmReadCtr = decryptedPiccData.slice(16, 22);
     const sv2 = "3cc300010080" + uid + sdmReadCtr;


### PR DESCRIPTION
## Summary

Normalize the NFC UID to lowercase before comparing it with decrypted PICC data in `testPAndC`. Fixes false "Test PICC: decrypt with key failed" results on Android when the UID contains A-F characters.

## Root cause

In `SetupBoltcard.tsx`, the app passes `tag?.id` from Android NFC into `Ntag424.testPAndC(...)`.

On Android, `tag?.id` is **uppercase** (e.g. `049F70FA967380`).

In `NTag424.tsx`, the decrypted PICC data is converted to hex with `CryptoJS.enc.Hex.stringify(decPiccData)`, which returns **lowercase** hex. The comparison:

```ts
if (decryptedPiccData.startsWith("c7" + uid)) result.pTest = true;
```

fails because:
- decrypted PICC data: `c7049f70fa967380...`
- expected prefix: `c7049F70FA967380`

The decryption succeeds — only the string comparison fails due to case.

## Fix

```diff
- if (decryptedPiccData.startsWith("c7" + uid)) result.pTest = true;
+ if (decryptedPiccData.startsWith("c7" + uid.toLowerCase())) result.pTest = true;
```

This aligns with the CMAC comparison in the same function, which already normalizes case with `cVal.toLowerCase()`.

## Verification

Confirmed the full source flow:
- `SetupBoltcard.tsx` passes `tag?.id` (uppercase on Android) into `Ntag424.testPAndC(...)`
- `NTag424.tsx` compares that UID against `CryptoJS.enc.Hex.stringify(decPiccData)` (lowercase)
- One-line fix normalizes the UID before comparison

Fixes #1
