### PR TITLE
Fix Paste Auth URL (sends pasted value under the wrong param key)

### DIFF
--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -236,7 +236,8 @@ export default function CreateBoltcardScreen() {
                                     router.replace({
                                         pathname: "/(tabs)/create",
                                         params: {
-                                            data: pasteUrlValue,
+                                            // screen reads `params.result` (not `data`) — see top of component
+                                            result: pasteUrlValue,
                                             timestamp: Date.now(),
                                         },
                                     });


### PR DESCRIPTION
## Problem

"Paste Auth URL" is a no-op. The Create screen reads its input from `params.result`:

```ts
const { result } = params;
const data = result ? result.toString() : null;
```

…but the paste dialog's **Continue** handler navigated with `params: { data: pasteUrlValue }` — the wrong key. The pasted value landed in `params.data`, which the screen never reads, so `data` stayed `null` and the screen just fell back to the "Scan QR Code / Paste Auth URL" prompt. Pasting a URL did nothing.

## Fix

Send the pasted value as `result` (the key the screen consumes). `resetAll()` also navigates with `data`, but only ever passes `null` to clear the screen, so it's unaffected.

Composes with #3: once the `boltcard://` deeplink unwrap lands, pasting a deeplink (not just a plain `https://` URL) works too, since both go through the same `result` → `parseBoltcardUrl` path.
