### PR TITLE
fix: preserve hub error reason, guard stale auth-info responses (WWT-122 follow-ups)

### DIFF
--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -140,11 +140,12 @@ export default function CreateBoltcardScreen() {
             setNdefRead(setNdefMessage);
 
             //we have the latest read from the card fire it off to the server.
-            const httpsLNURL = setNdefMessage.replace("lnurlw://", "https://");
+            const httpsLNURL = String(setNdefMessage.replace("lnurlw://", "https://")).trim();
             fetch(httpsLNURL)
                 .then((response) => {
                     if (!response.ok) {
-                        throw new Error(response.statusText);
+                        // statusText is commonly blank on React Native, so lead with the code.
+                        throw new Error(`Server returned ${response.status} ${response.statusText}`.trim());
                     }
                     return response.json();
                 })

--- a/app/components/DisplayAuthInfo.tsx
+++ b/app/components/DisplayAuthInfo.tsx
@@ -24,6 +24,10 @@ export default function DisplayAuthInfo(props: any) {
     useEffect(() => {
         if (!data || data == "") return;
 
+        // Guards against a slow response for a previous URL landing after the user
+        // has reset and pasted a new one, which would stage the wrong keys to write.
+        let cancelled = false;
+
         const loadAuthInfo = async () => {
             setLoading(true);
             setError(undefined);
@@ -47,25 +51,39 @@ export default function DisplayAuthInfo(props: any) {
                     });
                 }
 
-                if (!response.ok) {
-                    throw new Error(`Server returned ${response.status} ${response.statusText}`.trim());
+                // Read the body before checking the status: hubs report their failure
+                // detail as {status:"ERROR", reason:"..."} and may pair it with a 4xx,
+                // so rejecting on the status first would discard the only useful message.
+                const body = (await response.text()).trim();
+
+                let json;
+                if (body) {
+                    try {
+                        json = JSON.parse(body);
+                    } catch {
+                        json = undefined;
+                    }
                 }
 
-                const body = (await response.text()).trim();
+                if (cancelled) return;
+
+                const statusMessage = `Server returned ${response.status} ${response.statusText}`.trim();
+
+                if (json && json.status == "ERROR") {
+                    setError(json.reason || statusMessage);
+                    return;
+                }
+
+                if (!response.ok) {
+                    throw new Error(statusMessage);
+                }
+
                 if (!body) {
                     throw new Error("Server returned an empty response");
                 }
 
-                let json;
-                try {
-                    json = JSON.parse(body);
-                } catch {
+                if (!json) {
                     throw new Error("Server response was not valid JSON");
-                }
-
-                if (json.status == "ERROR") {
-                    setError(json.reason);
-                    return;
                 }
 
                 // Accept both the Bolt Card Hub uppercase schema (LNURLW, K0..K4) and the
@@ -78,7 +96,7 @@ export default function DisplayAuthInfo(props: any) {
                 const k4 = json.K4 || json.k4;
 
                 if (!(lnurlw && k0 && k1 && k2 && k3 && k4)) {
-                    setError("The JSON response must contain lnurlw_base, k0, k1, k2, k3, k4 ");
+                    setError("The JSON response must contain LNURLW and K0-K4 (or lnurlw_base and k0-k4)");
                     return;
                 }
 
@@ -90,13 +108,17 @@ export default function DisplayAuthInfo(props: any) {
                 setReadyToWrite(true);
             } catch (error: any) {
                 console.error(error);
-                setError(error.message);
+                if (!cancelled) setError(error.message);
             } finally {
-                setLoading(false);
+                if (!cancelled) setLoading(false);
             }
         };
 
         loadAuthInfo();
+
+        return () => {
+            cancelled = true;
+        };
     }, [data]);
 
     const key0display = keys[0] ? keys[0].substring(0, 4) + "............" + keys[0].substring(28) : "pending...";

--- a/app/components/SetupBoltcard.tsx
+++ b/app/components/SetupBoltcard.tsx
@@ -197,7 +197,8 @@ export default function SetupBoltcard({ url }: any) {
             fetch(httpsLNURL)
                 .then((response) => {
                     if (!response.ok) {
-                        throw new Error(response.statusText);
+                        // statusText is commonly blank on React Native, so lead with the code.
+                        throw new Error(`Server returned ${response.status} ${response.statusText}`.trim());
                     }
                     return response.json();
                 })


### PR DESCRIPTION
Follow-ups from the [WWT-122](https://linear.app/white-wolf-technology/issue/WWT-122/error-in-app-v060-preview) code review of #5. None of these affected the parse-error fix itself, which is why they weren't blocking — but they were only recorded on a now-closed ticket, so they're collected here.

The separate open question from that review — whether the preview POST consumes a batch keyset before the user writes a card — is tracked in [WWT-138](https://linear.app/white-wolf-technology/issue/WWT-138/preview-screen-post-consumes-a-batch-keyset-before-the-user-writes-a) and is **not** addressed here.

### Changes

**1. Hub error `reason` was being swallowed on non-2xx responses**

`DisplayAuthInfo` threw on `!response.ok` before it ever read the body, so a hub replying `{"status":"ERROR","reason":"batch exhausted"}` with a 4xx showed a bare `Server returned 400` instead of the reason. The body is now read and parsed first; `reason` is surfaced when present, then the status / empty-body / invalid-JSON errors fall through in the same order as before.

**2. No in-flight guard on the auth-info fetch**

The effect had no cleanup, so a slow response for a previous URL could still call `setKeys` / `setReadyToWrite(true)` after the user hit Reset and pasted a new one — staging the wrong keys to write. Added a `cancelled` flag with an effect cleanup, checked before any state write. The single gate sits after the last `await`, and everything past it is synchronous.

**3. Minor**

- `new Error(response.statusText)` rendered as a bare `Error: ` — `statusText` is commonly blank on React Native. Now leads with the status code, in both `create.tsx` and `SetupBoltcard.tsx` (identical line in the twin code path).
- `create.tsx` didn't trim the decoded NDEF before the bolt-call test, unlike the equivalent path in `SetupBoltcard.tsx:196`.
- Schema-mismatch message named only the lowercase keys despite the uppercase hub schema now being accepted.

### Verification

No test harness exists in this repo, so the static checks were diffed against the `master` baseline rather than asserted from inspection:

- `tsc --noEmit`: **215 errors before, 215 after** — every line in the diff is a pure line-number shift from the one-line insertions. No new errors. (The 215 are pre-existing: `Cmac.tsx` implicit-anys and untyped `useState` in the NFC flows.)
- `expo lint`: **154 problems before, 154 after**, identical. Warnings in the touched files are pre-existing house style.

Neither check exercises runtime behaviour — the item-1 branching and item-2 cancellation are reasoned-through, not proven against a live hub. Worth a manual pass on the Create tab before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPooJa9oPq6P97MHL4bECY